### PR TITLE
Move bs-jest to bs-dev-dependencies

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -9,7 +9,7 @@
       "type": "dev"
     }
   ],
-  "bs-dependencies": [
+  "bs-dev-dependencies": [
     "bs-jest"
   ]
 }


### PR DESCRIPTION
I can't install this package without installing bs-jest as well because bs-jest is listed as a devDependency in package.json but as a dependency in bsconfig.json