### PR TITLE
Add difference method

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -200,7 +200,7 @@ let () =
       fun () => {
         test
           "should return correct difference of moments in days"
-          (fun () => expect (diff (moment "2017-01-02") (moment "2017-01-01") `days) |> toBe 1);
+          (fun () => expect (diff (moment "2017-01-02") (moment "2017-01-01") `days) |> toBe 1.);
         test
           "should return correct difference of moments in hours"
           (
@@ -208,7 +208,7 @@ let () =
               expect (
                 diff (moment "2017-01-01 02:00:00.000") (moment "2017-01-01 00:00:00.000") `hours
               ) |>
-              toBe 2
+              toBe 2.
           );
         test
           "should be able to handle negative difference of moments"
@@ -217,7 +217,7 @@ let () =
               expect (
                 diff (moment "2017-01-01 00:00:00.000") (moment "2017-01-01 02:00:00.000") `hours
               ) |>
-              toBe (-2)
+              toBe (-2.)
           );
         test
           "should return correct difference of moments in hours"
@@ -226,7 +226,7 @@ let () =
               expect (
                 diff (moment "2017-01-01 00:25:05.000") (moment "2017-01-01 00:00:00.000") `minutes
               ) |>
-              toBe 25
+              toBe 25.
           )
       }
     );

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -211,6 +211,15 @@ let () =
               toBe 2
           );
         test
+          "should be able to handle negative difference of moments"
+          (
+            fun () =>
+              expect (
+                diff (moment "2017-01-01 00:00:00.000") (moment "2017-01-01 02:00:00.000") `hours
+              ) |>
+              toBe (-2)
+          );
+        test
           "should return correct difference of moments in hours"
           (
             fun () =>

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -192,3 +192,32 @@ let () =
           "#humanize" (fun () => expect (duration 2 `days |> Duration.humanize) |> toBe "2 days")
       }
     );
+
+let () =
+  describe
+    "moment diff"
+    ExpectJs.(
+      fun () => {
+        test
+          "should return correct difference of moments in days"
+          (fun () => expect (diff (moment "2017-01-02") (moment "2017-01-01") `days) |> toBe 1);
+        test
+          "should return correct difference of moments in hours"
+          (
+            fun () =>
+              expect (
+                diff (moment "2017-01-01 02:00:00.000") (moment "2017-01-01 00:00:00.000") `hours
+              ) |>
+              toBe 2
+          );
+        test
+          "should return correct difference of moments in hours"
+          (
+            fun () =>
+              expect (
+                diff (moment "2017-01-01 00:25:05.000") (moment "2017-01-01 00:00:00.000") `minutes
+              ) |>
+              toBe 25
+          )
+      }
+    );

--- a/src/momentRe.re
+++ b/src/momentRe.re
@@ -136,7 +136,7 @@ external diff :
   Moment.t =>
   [ | `years | `quarters | `months | `weeks | `days | `hours | `minutes | `seconds | `milliseconds]
   [@bs.string] =>
-  Moment.t =
+  int =
   "" [@@bs.send];
 
 let moment ::format=? value =>

--- a/src/momentRe.re
+++ b/src/momentRe.re
@@ -136,7 +136,7 @@ external diff :
   Moment.t =>
   [ | `years | `quarters | `months | `weeks | `days | `hours | `minutes | `seconds | `milliseconds]
   [@bs.string] =>
-  int =
+  float =
   "" [@@bs.send];
 
 let moment ::format=? value =>

--- a/src/momentRe.re
+++ b/src/momentRe.re
@@ -131,6 +131,14 @@ external momentWithTimestampMS : float => Moment.t = "moment" [@@bs.module];
 
 external momentWithComponents : list int => Moment.t = "moment" [@@bs.module];
 
+external diff :
+  Moment.t =>
+  Moment.t =>
+  [ | `years | `quarters | `months | `weeks | `days | `hours | `minutes | `seconds | `milliseconds]
+  [@bs.string] =>
+  Moment.t =
+  "" [@@bs.send];
+
 let moment ::format=? value =>
   switch format {
   | Some f => momentWithFormats value f

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,9 +311,9 @@ bs-jest@^0.1.0:
   dependencies:
     jest "^19.0.2"
 
-bs-platform@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-1.7.1.tgz#e05b0ca466115a0374d89141ba749b66a8e4ac07"
+bs-platform@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-1.9.1.tgz#1195562f0f8b131cc758693e7c9b31d7e0022001"
 
 bser@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Just to get the basic usage of the method I added some bindings for the moment().diff method. 

With these bindings we will only support the case of accepting a moment object as a parameter and time format string we wan't the result to be in.  i.e. `moment().diff(Moment, String);`

The usage for this would be:
``` 
/* Given two moment objects a and b*/
let a = MomentRe.moment "2017-01-01";
let b = MomentRe.moment "2017-01-02";
let diffInDays = MomentRe.diff b a `days; /* Will give us the difference of one day */
```
In the future I am hoping that myself or others could extend the use cases for this method. 
