### PR TITLE
Add unix methods

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -78,6 +78,17 @@ let () =
               ) |>
               toBe true
           );
+        test
+          "instantiation momentWithUnix (int)"
+          (
+            fun () =>
+              expect (
+                Moment.isSame
+                  (moment "2016-01-01")
+                  (momentWithUnix 1451602800)
+              ) |>
+              toBe true
+          );
         test ".now" (fun () => expect (momentNow () |> Moment.isValid) |> toBe true);
         test
           "#isSame"

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -146,6 +146,9 @@ let () =
           "#toDate"
           (fun () => expect (isJsDateValid (moment "2016-01-01" |> Moment.toDate)) |> toBe true);
         test
+          "#toUnix"
+          (fun () => expect (moment "2016-01-01" |> Moment.toUnix) |> toBe 1451602800);
+        test
           "#get"
           (fun () => expect (moment "2017-01-02 03:04:05.678" |> Moment.get `day) |> toBe 1);
         test

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -84,8 +84,8 @@ let () =
             fun () =>
               expect (
                 Moment.isSame
-                  (moment "2016-01-01")
-                  (momentWithUnix 1451602800)
+                  (moment "6 Mar 2017 21:22:23 GMT")
+                  (momentWithUnix 1488835343)
               ) |>
               toBe true
           );
@@ -158,7 +158,7 @@ let () =
           (fun () => expect (isJsDateValid (moment "2016-01-01" |> Moment.toDate)) |> toBe true);
         test
           "#toUnix"
-          (fun () => expect (moment "2016-01-01" |> Moment.toUnix) |> toBe 1451602800);
+          (fun () => expect (moment "6 Mar 2017 21:22:23 GMT" |> Moment.toUnix) |> toBe 1488835343);
         test
           "#get"
           (fun () => expect (moment "2017-01-02 03:04:05.678" |> Moment.get `day) |> toBe 1);

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -133,6 +133,8 @@ external momentWithTimestampMS : float => Moment.t = "moment" [@@bs.module];
 
 external momentWithComponents : list int => Moment.t = "moment" [@@bs.module];
 
+let momentWithUnix (timestamp: int) => momentWithTimestampMS(float_of_int timestamp *. 1000.0);
+
 external diff :
   Moment.t =>
   Moment.t =>

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -117,6 +117,7 @@ module Moment = {
   external daysInMonth : t => int = "" [@@bs.send];
   external toJSON : t => string = "" [@@bs.send];
   external toDate : t => Js.Date.t = "" [@@bs.send];
+  external toUnix : t => int = "unix" [@@bs.send];
 };
 
 /* parse */


### PR DESCRIPTION
I think it makes sense to split up the `unix()` method into `toUnix` and `momentFromUnix`, feel free to change if you disagree!