### PR TITLE
Add utc and locale 

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -133,6 +133,16 @@ let () =
             expect(moment("2016-01-01") |> Moment.defaultFormat) |> toContainString("2016-01-01")
         );
         test(
+          "#utc",
+          () =>
+            expect(momentNow() |> MomentRe.Moment.utc("2018-01-22") |> Moment.isValid) |> toBe(true)
+        );
+        test (
+          "#locale",
+          () =>
+            expect(moment("2016-01-01 00:00:00Z") |> Moment.locale("is_IS") |> Moment.format("LT")) |> toBe("0:00")
+        );
+        test(
           "#valueOf", /* TODO: float? */
           () =>
             expect(moment("2016-01-01 00:00:00Z") |> Moment.valueOf) |> toBeCloseTo(1451606400000.)

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -140,7 +140,7 @@ let () =
         test (
           "#locale",
           () =>
-            expect(moment("2016-01-01 00:00:00Z") |> Moment.locale("is_IS") |> Moment.format("LT")) |> toBe("0:00")
+            expect(moment("2018-01-01 00:00:00Z") |> Moment.locale("da_DK") |> Moment.format("MMMM Do YYYY")) |> toBe("januar 1. 2018")
         );
         test(
           "#valueOf", /* TODO: float? */

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -134,6 +134,8 @@ module Moment = {
   /* display */
   [@bs.send.pipe : t] external format : string => string = "";
   [@bs.send.pipe : t] external defaultFormat : string = "format";
+  [@bs.send.pipe : t] external utc : string => t = "";
+  [@bs.send.pipe : t] external locale : string => t = "";
   [@bs.send] external fromNow : (t, ~withoutSuffix: option(bool)) => string = "";
   [@bs.send] external fromMoment : (t, ~other: t, ~format: option(string)) => string = "from";
   [@bs.send] external toNow : (t, ~withoutSuffix: option(bool)) => string = "";


### PR DESCRIPTION
- Added bindings for `moment().utc` and `moment().locale `
- Added tests for utc and locale

@Jimexist 