### PR TITLE
Add days variant to get

### DIFF
--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -231,6 +231,7 @@ module Moment = {
       | `month
       | `week
       | `day
+      | `date
       | `hour
       | `minute
       | `second


### PR DESCRIPTION
Added `` `date`` variant to `get` which returns a day of month ( `` `day`` returns a day of week).
@Jimexist 