### PR TITLE
Add isoweek to startOf and endOf

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -668,12 +668,12 @@ let () =
           expect(Moment.isSame(expected, Moment.startOf(`week, inputDate)))
           |> toBe(true);
         });
-        test("#startOf isoweek", () => {
+        test("#startOf isoWeek", () => {
           let inputDate = moment("2017-01-10 03:04:05.678");
           let expected = moment("2017-01-09T00:00:00.000");
 
           expect(
-            Moment.isSame(expected, Moment.startOf(`isoweek, inputDate)),
+            Moment.isSame(expected, Moment.startOf(`isoWeek, inputDate)),
           )
           |> toBe(true);
         });
@@ -684,11 +684,11 @@ let () =
           expect(Moment.isSame(expected, Moment.endOf(`week, inputDate)))
           |> toBe(true);
         });
-        test("#endOf isoweek", () => {
+        test("#endOf isoWeek", () => {
           let inputDate = moment("2017-01-10 03:04:05.678");
           let expected = moment("2017-01-15T23:59:59.999");
 
-          expect(Moment.isSame(expected, Moment.endOf(`isoweek, inputDate)))
+          expect(Moment.isSame(expected, Moment.endOf(`isoWeek, inputDate)))
           |> toBe(true);
         });
       }

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -661,6 +661,36 @@ let () =
           expect(moment("2017-01-02 03:04:05.678") |> Moment.weekday)
           |> toBe(1)
         );
+        test("#startOf week", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-08T00:00:00.000");
+
+          expect(Moment.isSame(expected, Moment.startOf(`week, inputDate)))
+          |> toBe(true);
+        });
+        test("#startOf isoweek", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-09T00:00:00.000");
+
+          expect(
+            Moment.isSame(expected, Moment.startOf(`isoweek, inputDate)),
+          )
+          |> toBe(true);
+        });
+        test("#endOf week", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-14T23:59:59.999");
+
+          expect(Moment.isSame(expected, Moment.endOf(`week, inputDate)))
+          |> toBe(true);
+        });
+        test("#endOf isoweek", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-15T23:59:59.999");
+
+          expect(Moment.isSame(expected, Moment.endOf(`isoweek, inputDate)))
+          |> toBe(true);
+        });
       }
     ),
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-moment",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "BuckleScript bindings for Moment.js",
   "main": "lib/js/src/MomentRe.js",
   "repository": "git@github.com:BuckleTypes/bs-moment.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-moment",
-  "version": "0.4.3",
+  "version": "0.4.2",
   "description": "BuckleScript bindings for Moment.js",
   "main": "lib/js/src/MomentRe.js",
   "repository": "git@github.com:BuckleTypes/bs-moment.git",

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -88,6 +88,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
+        | `isoweek
         | `day
         | `hour
         | `minute
@@ -111,6 +112,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
+        | `isoweek
         | `day
         | `hour
         | `minute

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -88,7 +88,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
-        | `isoweek
+        | `isoWeek
         | `day
         | `hour
         | `minute
@@ -112,7 +112,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
-        | `isoweek
+        | `isoWeek
         | `day
         | `hour
         | `minute


### PR DESCRIPTION
I have noticed that in moment library, methods: startOf and endOf can take string: isoweek (https://momentjs.com/docs/#/manipulating/start-of/)
I added it to handle isoweek in bs-moment