### PR TITLE
Handle moment.utc

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -668,12 +668,12 @@ let () =
           expect(Moment.isSame(expected, Moment.startOf(`week, inputDate)))
           |> toBe(true);
         });
-        test("#startOf isoweek", () => {
+        test("#startOf isoWeek", () => {
           let inputDate = moment("2017-01-10 03:04:05.678");
           let expected = moment("2017-01-09T00:00:00.000");
 
           expect(
-            Moment.isSame(expected, Moment.startOf(`isoweek, inputDate)),
+            Moment.isSame(expected, Moment.startOf(`isoWeek, inputDate)),
           )
           |> toBe(true);
         });
@@ -684,11 +684,11 @@ let () =
           expect(Moment.isSame(expected, Moment.endOf(`week, inputDate)))
           |> toBe(true);
         });
-        test("#endOf isoweek", () => {
+        test("#endOf isoWeek", () => {
           let inputDate = moment("2017-01-10 03:04:05.678");
           let expected = moment("2017-01-15T23:59:59.999");
 
-          expect(Moment.isSame(expected, Moment.endOf(`isoweek, inputDate)))
+          expect(Moment.isSame(expected, Moment.endOf(`isoWeek, inputDate)))
           |> toBe(true);
         });
       }

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -692,7 +692,7 @@ let () =
           |> toBe(true);
         });
 
-        test("#momentUtc Z", () => {
+        test("#momentUtc Z (default format)", () => {
           let dateStr = "2017-01-10T03:04";
 
           expect(
@@ -701,10 +701,31 @@ let () =
           |> toBe(dateStr);
         });
 
-        test("#momentUtc no Z", () => {
+        test("#momentUtc no Z (default format)", () => {
           let dateStr = "2017-01-10T03:04";
 
           expect(momentUtc(dateStr) |> Moment.format("YYYY-MM-DDTHH:mm"))
+          |> toBe(dateStr);
+        });
+
+        test("#momentUtc Z (format defined)", () => {
+          let format = "DD-MM-YYYY HH : ss";
+          let dateStr = "10-01-2017 03 : 04";
+
+          expect(
+            momentUtc(~format=[|format|], dateStr ++ "Z")
+            |> Moment.format(format),
+          )
+          |> toBe(dateStr);
+        });
+
+        test("#momentUtc no Z (format defined)", () => {
+          let format = "DD-MM-YYYY HH : ss";
+          let dateStr = "10-01-2017 03 : 04";
+
+          expect(
+            momentUtc(~format=[|format|], dateStr) |> Moment.format(format),
+          )
           |> toBe(dateStr);
         });
       }

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -692,6 +692,16 @@ let () =
           |> toBe(true);
         });
 
+        test("#moment (format defined)", () => {
+          let format = "DD-MM-YYYY HH : ss";
+          let dateStr = "10-01-2017 03 : 04";
+
+          expect(
+            moment(~format=[|format|], dateStr) |> Moment.format(format),
+          )
+          |> toBe(dateStr);
+        });
+
         test("#momentUtc Z (default format)", () => {
           let dateStr = "2017-01-10T03:04";
 

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -691,6 +691,22 @@ let () =
           expect(Moment.isSame(expected, Moment.endOf(`isoWeek, inputDate)))
           |> toBe(true);
         });
+
+        test("#momentUtc Z", () => {
+          let dateStr = "2017-01-10T03:04";
+
+          expect(
+            momentUtc(dateStr ++ "Z") |> Moment.format("YYYY-MM-DDTHH:mm"),
+          )
+          |> toBe(dateStr);
+        });
+
+        test("#momentUtc no Z", () => {
+          let dateStr = "2017-01-10T03:04";
+
+          expect(momentUtc(dateStr) |> Moment.format("YYYY-MM-DDTHH:mm"))
+          |> toBe(dateStr);
+        });
       }
     ),
   );

--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -661,6 +661,36 @@ let () =
           expect(moment("2017-01-02 03:04:05.678") |> Moment.weekday)
           |> toBe(1)
         );
+        test("#startOf week", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-08T00:00:00.000");
+
+          expect(Moment.isSame(expected, Moment.startOf(`week, inputDate)))
+          |> toBe(true);
+        });
+        test("#startOf isoweek", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-09T00:00:00.000");
+
+          expect(
+            Moment.isSame(expected, Moment.startOf(`isoweek, inputDate)),
+          )
+          |> toBe(true);
+        });
+        test("#endOf week", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-14T23:59:59.999");
+
+          expect(Moment.isSame(expected, Moment.endOf(`week, inputDate)))
+          |> toBe(true);
+        });
+        test("#endOf isoweek", () => {
+          let inputDate = moment("2017-01-10 03:04:05.678");
+          let expected = moment("2017-01-15T23:59:59.999");
+
+          expect(Moment.isSame(expected, Moment.endOf(`isoweek, inputDate)))
+          |> toBe(true);
+        });
       }
     ),
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-moment",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "BuckleScript bindings for Moment.js",
   "main": "lib/js/src/MomentRe.js",
   "repository": "git@github.com:BuckleTypes/bs-moment.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-moment",
-  "version": "0.4.3",
+  "version": "0.4.2",
   "description": "BuckleScript bindings for Moment.js",
   "main": "lib/js/src/MomentRe.js",
   "repository": "git@github.com:BuckleTypes/bs-moment.git",

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -303,7 +303,11 @@ external momentWithFormats: (string, list(string)) => Moment.t = "moment";
 
 [@bs.module] external momentWithComponents: list(int) => Moment.t = "moment";
 
-[@bs.module "moment"] external momentUtc: string => Moment.t = "utc";
+[@bs.module "moment"]
+external momentUtcWithFormats: (string, array(string)) => Moment.t = "utc";
+
+[@bs.module "moment"]
+external momentUtcDefaultFormat: string => Moment.t = "utc";
 
 let momentWithUnix = (timestamp: int) =>
   momentWithTimestampMS(float_of_int(timestamp) *. 1000.0);
@@ -327,6 +331,12 @@ external diff:
   ) =>
   float =
   "";
+
+let momentUtc = (~format=?, value) =>
+  switch (format) {
+  | Some(f) => momentUtcWithFormats(value, f)
+  | None => momentUtcDefaultFormat(value)
+  };
 
 let moment = (~format=?, value) =>
   switch (format) {

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -297,7 +297,7 @@ external momentWithFormat: (string, string) => Moment.t = "moment";
 [@bs.module] external momentWithDate: Js.Date.t => Moment.t = "moment";
 
 [@bs.module]
-external momentWithFormats: (string, list(string)) => Moment.t = "moment";
+external momentWithFormats: (string, array(string)) => Moment.t = "moment";
 
 [@bs.module] external momentWithTimestampMS: float => Moment.t = "moment";
 

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -88,6 +88,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
+        | `isoweek
         | `day
         | `hour
         | `minute
@@ -111,6 +112,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
+        | `isoweek
         | `day
         | `hour
         | `minute

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -303,6 +303,8 @@ external momentWithFormats: (string, list(string)) => Moment.t = "moment";
 
 [@bs.module] external momentWithComponents: list(int) => Moment.t = "moment";
 
+[@bs.module "moment"] external momentUtc: string => Moment.t = "utc";
+
 let momentWithUnix = (timestamp: int) =>
   momentWithTimestampMS(float_of_int(timestamp) *. 1000.0);
 

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -88,7 +88,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
-        | `isoweek
+        | `isoWeek
         | `day
         | `hour
         | `minute
@@ -112,7 +112,7 @@ module Moment = {
         | `quarter
         | `month
         | `week
-        | `isoweek
+        | `isoWeek
         | `day
         | `hour
         | `minute


### PR DESCRIPTION
In moment library there is a function `moment.utc` (https://momentjs.com/docs/#/parsing/utc/), which can take string and return moment object. In bs-moment there no bindig for this. There is a binding on `moment(str).utc()` which is not the same as `moment.utc(str)`. 
I think that good to handle `moment.utc` in bs-moment.
