### PR TITLE
diff captures the 3rd bool arg

### DIFF
--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -362,7 +362,8 @@ external diff:
       | `minutes
       | `seconds
       | `milliseconds
-    ]
+    ],
+    bool
   ) =>
   float =
   "";


### PR DESCRIPTION
diff captures the 3rd bool arg, which when true returns float. defaults to return int.