### PR TITLE
Add method diff with precision to Moment bindings

### DIFF
--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -367,6 +367,27 @@ external diff:
   float =
   "";
 
+  [@bs.send]
+external diffWithPrecision:
+  (
+    Moment.t,
+    Moment.t,
+    [@bs.string] [
+      | `years
+      | `quarters
+      | `months
+      | `weeks
+      | `days
+      | `hours
+      | `minutes
+      | `seconds
+      | `milliseconds
+    ],
+    bool
+  ) =>
+  float =
+  "diff";
+
 let momentUtc = (~format=?, value) =>
   switch (format) {
   | Some(f) => momentUtcWithFormats(value, f)


### PR DESCRIPTION
I needed to use the Moment diff function with the precision param to get the days with decimals. 

With this change, you will be able to send a boolean to return or not the precision when you are trying to get the difference in days (In my case).