### PR TITLE
Make return type of toJSON nullable

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -668,10 +668,16 @@ let () =
           expect(moment("2016-01-01 00:00:00Z") |> Moment.valueOf)
           |> toBeCloseTo(1451606400000.)
         );
-        test("#toJSON", () =>
-          expect(moment("2016-01-01") |> Moment.toJSON)
-          |> toContainString("000Z")
-        );
+        describe("#toJSON", () => {
+          test("valid", () =>
+            expect(moment("2016-01-01") |> Moment.toJSON |> Belt.Option.getExn)
+            |> toContainString("000Z")
+          );
+          test("invalid", () =>
+            expect(moment("9999-99-99") |> Moment.toJSON)
+            |> toBe(None)
+          );
+        });
         test("#toDate", () =>
           expect(isJsDateValid(moment("2016-01-01") |> Moment.toDate))
           |> toBe(true)
@@ -680,6 +686,18 @@ let () =
           expect(moment("6 Mar 2017 21:22:23 GMT") |> Moment.toUnix)
           |> toBe(1488835343)
         );
+        describe("#toISOString", () => {
+          test("default", () =>
+            expect(moment("6 Mar 2017 21:22:23 GMT") |> Moment.toISOString)
+            |> toBe("2017-03-06T21:22:23.000Z")
+          );
+          test("keepOffset", () =>
+            moment("6 Mar 2017 21:22:23 GMT") |> Moment.toISOString(~keepOffset=true)
+            |> Js.String.includes("000Z")
+            |> expect
+            |> toBe(false)
+          );
+        });
         test("#get", () =>
           expect(moment("2017-01-02 03:04:05.678") |> Moment.get(`day))
           |> toBe(1)
@@ -865,6 +883,9 @@ let () =
           |> toBe(2.)
         );
         test("#toJSON", () =>
+          expect(duration(2., `days) |> Duration.toJSON) |> toBe("P2D")
+        );
+        test("#toISOString", () =>
           expect(duration(2., `days) |> Duration.toJSON) |> toBe("P2D")
         );
         test("#humanize", () =>

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -19,6 +19,7 @@ module Duration = {
   [@bs.send] external years: t => int = "";
   [@bs.send] external asYears: t => float = "";
   [@bs.send] external toJSON: t => string = "";
+  [@bs.send] external toISOString: t => string = "";
   [@bs.send.pipe: t]
   external asUnitOfTime:
     (
@@ -316,9 +317,11 @@ module Moment = {
   external toMoment: (t, ~other: t, ~format: string) => string = "to";
   [@bs.send] external valueOf: t => float = "";
   [@bs.send] external daysInMonth: t => int = "";
-  [@bs.send] external toJSON: t => string = "";
+  [@bs.send] external toJSON: t => Js.null(string) = "";
+  let toJSON = (moment) => toJSON(moment) |> Js.Null.toOption;
   [@bs.send] external toDate: t => Js.Date.t = "";
   [@bs.send] external toUnix: t => int = "unix";
+  [@bs.send.pipe: t] external toISOString: (~keepOffset: bool=?) => string = "";
 };
 
 /* parse */


### PR DESCRIPTION
Moment.toJSON returns null for invalid dates. This PR makes it so that the binding matches this behavior.

Also, added toISOString to moments and durations.