### PR TITLE
durationMillis should accept float instead of int

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -809,7 +809,7 @@ let () =
           expect(duration(2., `days)) |> toBeTruthy
         );
         test("get duration millis", () =>
-          expect(durationMillis(2)) |> toBeTruthy
+          expect(durationMillis(2.0)) |> toBeTruthy
         );
         test("get duration format", () =>
           expect(durationFormat("P2D") |> Duration.toJSON) |> toBe("P2D")

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -58,7 +58,7 @@ external duration:
   Duration.t =
   "";
 
-[@bs.module "moment"] external durationMillis: int => Duration.t = "duration";
+[@bs.module "moment"] external durationMillis: float => Duration.t = "duration";
 
 [@bs.module "moment"]
 external durationFormat: string => Duration.t = "duration";


### PR DESCRIPTION
When we receive float values from functions like `Js.Date.now`, we're forced to use `int_of_float` which truncates values causing an overflow. 